### PR TITLE
Make tests succeed again

### DIFF
--- a/android/src/test/java/com/onegini/mobile/sdk/AuthenticateDeviceUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/AuthenticateDeviceUseCaseTests.kt
@@ -57,7 +57,8 @@ class AuthenticateDeviceUseCaseTests {
         }
         AuthenticateDeviceUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(oneginiDeviceAuthenticationErrorMock.errorType.toString(), oneginiDeviceAuthenticationErrorMock.message, null)
+        val message = oneginiDeviceAuthenticationErrorMock.message
+        verify(resultSpy).error(eq(oneginiDeviceAuthenticationErrorMock.errorType.toString()), eq(message), any())
     }
 
     @Test
@@ -78,7 +79,7 @@ class AuthenticateDeviceUseCaseTests {
         AuthenticateDeviceUseCase(clientMock)(callMock, resultSpy)
 
         argumentCaptor<Array<String>> {
-            Mockito.verify(deviceClientMock).authenticateDevice(capture(), ArgumentMatchers.any())
+            verify(deviceClientMock).authenticateDevice(capture(), ArgumentMatchers.any())
             Truth.assertThat(firstValue.size).isEqualTo(2)
             Truth.assertThat(firstValue).isEqualTo(arrayOf("read", "write"))
         }

--- a/android/src/test/java/com/onegini/mobile/sdk/AuthenticateUserImplicitlyUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/AuthenticateUserImplicitlyUseCaseTests.kt
@@ -108,7 +108,7 @@ class AuthenticateUserImplicitlyUseCaseTests {
     AuthenticateUserImplicitlyUseCase(clientMock)(callMock, resultSpy)
 
     argumentCaptor<Array<String>> {
-      Mockito.verify(userClientMock).authenticateUserImplicitly(eq(UserProfile("QWERTY")), capture(), ArgumentMatchers.any())
+      verify(userClientMock).authenticateUserImplicitly(eq(UserProfile("QWERTY")), capture(), ArgumentMatchers.any())
       Truth.assertThat(firstValue.size).isEqualTo(2)
       Truth.assertThat(firstValue).isEqualTo(arrayOf("read", "write"))
     }

--- a/android/src/test/java/com/onegini/mobile/sdk/AuthenticateUserUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/AuthenticateUserUseCaseTests.kt
@@ -21,6 +21,7 @@ import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -62,7 +63,7 @@ class AuthenticateUserUseCaseTests {
         val userProfileJson = mapOf("profileId" to "QWERTY", "isDefault" to false)
         val customInfoJson = mapOf("data" to "", "status" to 0)
         val expectedResult = Gson().toJson(mapOf("userProfile" to userProfileJson, "customInfo" to customInfoJson))
-        Mockito.verify(resultSpy).success(expectedResult)
+        verify(resultSpy).success(expectedResult)
     }
 
     @Test
@@ -72,7 +73,8 @@ class AuthenticateUserUseCaseTests {
 
         AuthenticateUserUseCase(clientMock)(callMock, resultSpy)
 
-        Mockito.verify(resultSpy).error(USER_PROFILE_DOES_NOT_EXIST.code.toString(), USER_PROFILE_DOES_NOT_EXIST.message, null)
+        val message = USER_PROFILE_DOES_NOT_EXIST.message
+        verify(resultSpy).error(eq(USER_PROFILE_DOES_NOT_EXIST.code.toString()), eq(message), any())
     }
 
     @Test
@@ -83,7 +85,8 @@ class AuthenticateUserUseCaseTests {
 
         AuthenticateUserUseCase(clientMock)(callMock, resultSpy)
 
-        Mockito.verify(resultSpy).error(AUTHENTICATOR_NOT_FOUND.code.toString(), AUTHENTICATOR_NOT_FOUND.message, null)
+        val message = AUTHENTICATOR_NOT_FOUND.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_NOT_FOUND.code.toString()), eq(message), any())
     }
 
     @Test
@@ -101,7 +104,7 @@ class AuthenticateUserUseCaseTests {
         val userProfileJson = mapOf("profileId" to "QWERTY", "isDefault" to false)
         val customInfoJson = mapOf("data" to "", "status" to 0)
         val expectedResult = Gson().toJson(mapOf("userProfile" to userProfileJson, "customInfo" to customInfoJson))
-        Mockito.verify(resultSpy).success(expectedResult)
+        verify(resultSpy).success(expectedResult)
     }
 
     @Test
@@ -116,7 +119,8 @@ class AuthenticateUserUseCaseTests {
 
         AuthenticateUserUseCase(clientMock)(callMock, resultSpy)
 
-        Mockito.verify(resultSpy).error(oneginiAuthenticationErrorMock.errorType.toString(), oneginiAuthenticationErrorMock.message, null)
+        val message = oneginiAuthenticationErrorMock.message
+        verify(resultSpy).error(eq(oneginiAuthenticationErrorMock.errorType.toString()), eq(message), any())
     }
 
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/DeregisterAuthenticatorUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/DeregisterAuthenticatorUseCaseTests.kt
@@ -54,7 +54,8 @@ class DeregisterAuthenticatorUseCaseTests {
 
         DeregisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(USER_PROFILE_DOES_NOT_EXIST.code.toString(), USER_PROFILE_DOES_NOT_EXIST.message, null)
+        val message = USER_PROFILE_DOES_NOT_EXIST.message
+        verify(resultSpy).error(eq(USER_PROFILE_DOES_NOT_EXIST.code.toString()), eq(message), any()) 
     }
 
     @Test
@@ -65,7 +66,8 @@ class DeregisterAuthenticatorUseCaseTests {
 
         DeregisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_IS_NULL.code.toString(), AUTHENTICATOR_IS_NULL.message, null)
+        val message = AUTHENTICATOR_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_IS_NULL.code.toString()), eq(message), any()) 
     }
 
     @Test
@@ -76,7 +78,8 @@ class DeregisterAuthenticatorUseCaseTests {
 
         DeregisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_IS_NULL.code.toString(), AUTHENTICATOR_IS_NULL.message, null)
+        val message = AUTHENTICATOR_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_IS_NULL.code.toString()), eq(message), any()) 
     }
 
     @Test
@@ -108,7 +111,8 @@ class DeregisterAuthenticatorUseCaseTests {
 
         DeregisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(oneginiAuthenticatorDeregistrationErrorMock.errorType.toString(), oneginiAuthenticatorDeregistrationErrorMock.message, null)
+        val message = oneginiAuthenticatorDeregistrationErrorMock.message
+        verify(resultSpy).error(eq(oneginiAuthenticatorDeregistrationErrorMock.errorType.toString()), eq(message), any()) 
     }
 
 

--- a/android/src/test/java/com/onegini/mobile/sdk/DeregisterUserUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/DeregisterUserUseCaseTests.kt
@@ -47,7 +47,8 @@ class DeregisterUserUseCaseTests {
     fun `should return error when user not authenticated`() {
         DeregisterUserUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(USER_PROFILE_DOES_NOT_EXIST.code.toString(), USER_PROFILE_DOES_NOT_EXIST.message, null)
+        val message = USER_PROFILE_DOES_NOT_EXIST.message
+        verify(resultSpy).error(eq(USER_PROFILE_DOES_NOT_EXIST.code.toString()), eq(message), any())
     }
 
     @Test
@@ -76,6 +77,7 @@ class DeregisterUserUseCaseTests {
 
         DeregisterUserUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(oneginiDeregistrationErrorMock.errorType.toString(), oneginiDeregistrationErrorMock.message, null)
+        val message = oneginiDeregistrationErrorMock.message
+        verify(resultSpy).error(eq(oneginiDeregistrationErrorMock.errorType.toString()), eq(message), any())
     }
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetAccessTokenUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetAccessTokenUseCaseTests.kt
@@ -12,6 +12,7 @@ import org.mockito.Mockito
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -37,7 +38,7 @@ class GetAccessTokenUseCaseTests {
 
         GetAccessTokenUseCase(clientMock)(resultSpy)
 
-        Mockito.verify(resultSpy).success(null)
+        verify(resultSpy).success(null)
     }
 
     @Test
@@ -46,6 +47,6 @@ class GetAccessTokenUseCaseTests {
 
         GetAccessTokenUseCase(clientMock)(resultSpy)
 
-        Mockito.verify(resultSpy).success(eq("test access token"))
+        verify(resultSpy).success(eq("test access token"))
     }
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetAllAuthenticatorsUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetAllAuthenticatorsUseCaseTests.kt
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -45,7 +47,8 @@ class GetAllAuthenticatorsUseCaseTests {
 
         GetAllAuthenticatorsUseCase(clientMock)(resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString(), AUTHENTICATED_USER_PROFILE_IS_NULL.message, null)
+        val message = AUTHENTICATED_USER_PROFILE_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test

--- a/android/src/test/java/com/onegini/mobile/sdk/GetAuthenticatedUserProfileUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetAuthenticatedUserProfileUseCaseTests.kt
@@ -15,6 +15,7 @@ import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -40,7 +41,7 @@ class GetAuthenticatedUserProfileUseCaseTests {
 
         GetAuthenticatedUserProfileUseCase(clientMock)(resultSpy)
 
-        Mockito.verify(resultSpy).success(isNull())
+        verify(resultSpy).success(isNull())
     }
 
     @Test
@@ -51,6 +52,6 @@ class GetAuthenticatedUserProfileUseCaseTests {
 
         val expectedResult = Gson().toJson(mapOf("profileId" to "QWERTY", "isDefault" to false))
         
-        Mockito.verify(resultSpy).success(eq(expectedResult))
+        verify(resultSpy).success(eq(expectedResult))
     }
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetImplicitResourceUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetImplicitResourceUseCaseTests.kt
@@ -92,7 +92,7 @@ class GetImplicitResourceUseCaseTests {
 
 
         argumentCaptor<OkHttpClient> {
-            Mockito.verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
+            verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
             Truth.assertThat(firstValue).isEqualTo(implicitResourceOkHttpClientMock)
         }
     }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetNotRegisteredAuthenticatorsUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetNotRegisteredAuthenticatorsUseCaseTests.kt
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -58,7 +59,8 @@ class GetNotRegisteredAuthenticatorsUseCaseTests {
 
         GetNotRegisteredAuthenticatorsUseCase(clientMock)(resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString(), AUTHENTICATED_USER_PROFILE_IS_NULL.message, null)
+        val message = AUTHENTICATED_USER_PROFILE_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test

--- a/android/src/test/java/com/onegini/mobile/sdk/GetRedirectUrlUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetRedirectUrlUseCaseTests.kt
@@ -12,6 +12,7 @@ import org.mockito.Mockito
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -37,7 +38,7 @@ class GetRedirectUrlUseCaseTests {
 
         GetRedirectUrlUseCase(clientMock)(resultSpy)
 
-        Mockito.verify(resultSpy).success("")
+        verify(resultSpy).success("")
     }
 
     @Test
@@ -46,6 +47,6 @@ class GetRedirectUrlUseCaseTests {
 
         GetRedirectUrlUseCase(clientMock)(resultSpy)
 
-        Mockito.verify(resultSpy).success("http://test.com")
+        verify(resultSpy).success("http://test.com")
     }
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetRegisteredAuthenticatorsUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetRegisteredAuthenticatorsUseCaseTests.kt
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -58,7 +59,8 @@ class GetRegisteredAuthenticatorsUseCaseTests {
 
         GetRegisteredAuthenticatorsUseCase(clientMock)(resultSpy)
 
-        verify(resultSpy).error(USER_PROFILE_DOES_NOT_EXIST.code.toString(), USER_PROFILE_DOES_NOT_EXIST.message, null)
+        val message = USER_PROFILE_DOES_NOT_EXIST.message
+        verify(resultSpy).error(eq(USER_PROFILE_DOES_NOT_EXIST.code.toString()), eq(message), any())
     }
 
     @Test

--- a/android/src/test/java/com/onegini/mobile/sdk/GetResourceAnonymousUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetResourceAnonymousUseCaseTests.kt
@@ -75,7 +75,7 @@ class GetResourceAnonymousUseCaseTests {
         GetResourceAnonymousUseCase(clientMock)(callMock, resultSpy, resourceHelper)
 
         argumentCaptor<OkHttpClient> {
-            Mockito.verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
+            verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
             Truth.assertThat(firstValue).isEqualTo(anonymousResourceOkHttpClientMock)
         }
     }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetResourceUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetResourceUseCaseTests.kt
@@ -76,7 +76,7 @@ class GetResourceUseCaseTests {
         GetResourceUseCase(clientMock)(callMock, resultSpy, resourceHelper)
 
         argumentCaptor<OkHttpClient> {
-            Mockito.verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
+            verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
             Truth.assertThat(firstValue).isEqualTo(resourceOkHttpClient)
         }
     }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetUnauthenticatedResourceUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetUnauthenticatedResourceUseCaseTests.kt
@@ -75,7 +75,7 @@ class GetUnauthenticatedResourceUseCaseTests {
         GetUnauthenticatedResourceUseCase(clientMock)(callMock, resultSpy, resourceHelper)
 
         argumentCaptor<OkHttpClient> {
-            Mockito.verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
+            verify(resourceHelper).callRequest(capture(), eq(requestMock), eq(resultSpy))
             Truth.assertThat(firstValue).isEqualTo(unauthenticatedResourceOkHttpClient)
         }
     }

--- a/android/src/test/java/com/onegini/mobile/sdk/GetUserProfileUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/GetUserProfileUseCaseTests.kt
@@ -14,6 +14,7 @@ import org.mockito.Mockito
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -39,7 +40,7 @@ class GetUserProfileUseCaseTests {
 
         GetUserProfilesUseCase(clientMock)(resultSpy)
 
-        Mockito.verify(resultSpy).success(Gson().toJson(emptySet<UserProfile>()))
+        verify(resultSpy).success(Gson().toJson(emptySet<UserProfile>()))
     }
 
     @Test
@@ -49,7 +50,7 @@ class GetUserProfileUseCaseTests {
         GetUserProfilesUseCase(clientMock)(resultSpy)
 
         val expectedResult = Gson().toJson(setOf(mapOf( "isDefault" to false, "profileId" to "QWERTY")))
-        Mockito.verify(resultSpy).success(eq(expectedResult))
+        verify(resultSpy).success(eq(expectedResult))
     }
 
     @Test
@@ -59,6 +60,6 @@ class GetUserProfileUseCaseTests {
         GetUserProfilesUseCase(clientMock)(resultSpy)
 
         val expectedResult = Gson().toJson(setOf(mapOf("isDefault" to false, "profileId" to "QWERTY"),mapOf("isDefault" to false, "profileId" to "ASDFGH")))
-        Mockito.verify(resultSpy).success(eq(expectedResult))
+        verify(resultSpy).success(eq(expectedResult))
     }
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/IsAuthenticatorRegisteredUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/IsAuthenticatorRegisteredUseCaseTests.kt
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -49,7 +51,8 @@ class IsAuthenticatorRegisteredUseCaseTests {
 
         IsAuthenticatorRegisteredUseCase(clientMock)(callMock,resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString(), AUTHENTICATED_USER_PROFILE_IS_NULL.message, null)
+        val message = AUTHENTICATED_USER_PROFILE_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test
@@ -58,7 +61,8 @@ class IsAuthenticatorRegisteredUseCaseTests {
 
         IsAuthenticatorRegisteredUseCase(clientMock)(callMock,resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_NOT_FOUND.code.toString(), AUTHENTICATOR_NOT_FOUND.message, null)
+        val message = AUTHENTICATOR_NOT_FOUND.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_NOT_FOUND.code.toString()), eq(message), any())
     }
 
     @Test
@@ -70,7 +74,8 @@ class IsAuthenticatorRegisteredUseCaseTests {
 
         IsAuthenticatorRegisteredUseCase(clientMock)(callMock,resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_NOT_FOUND.code.toString(), AUTHENTICATOR_NOT_FOUND.message, null)
+        val message = AUTHENTICATOR_NOT_FOUND.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_NOT_FOUND.code.toString()), eq(message), any())
     }
 
     @Test

--- a/android/src/test/java/com/onegini/mobile/sdk/LogoutUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/LogoutUseCaseTests.kt
@@ -13,6 +13,7 @@ import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -57,6 +58,7 @@ class LogoutUseCaseTests {
 
         LogoutUseCase(clientMock)(resultSpy)
 
-        verify(resultSpy).error(oneginiLogoutError.errorType.toString(), oneginiLogoutError.message, null)
+        val message = oneginiLogoutError.message
+        verify(resultSpy).error(eq(oneginiLogoutError.errorType.toString()), eq(message), any())
     }
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/RegisterAuthenticatorUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/RegisterAuthenticatorUseCaseTests.kt
@@ -55,7 +55,8 @@ class RegisterAuthenticatorUseCaseTests {
 
         RegisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString(), AUTHENTICATED_USER_PROFILE_IS_NULL.message, null)
+        val message = AUTHENTICATED_USER_PROFILE_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATED_USER_PROFILE_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test
@@ -66,7 +67,8 @@ class RegisterAuthenticatorUseCaseTests {
 
         RegisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_IS_NULL.code.toString(), AUTHENTICATOR_IS_NULL.message, null)
+        val message = AUTHENTICATOR_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test
@@ -77,7 +79,8 @@ class RegisterAuthenticatorUseCaseTests {
 
         RegisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_IS_NULL.code.toString(), AUTHENTICATOR_IS_NULL.message, null)
+        val message = AUTHENTICATOR_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test
@@ -109,6 +112,7 @@ class RegisterAuthenticatorUseCaseTests {
 
         RegisterAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(oneginiAuthenticatorRegistrationErrorMock.errorType.toString(), oneginiAuthenticatorRegistrationErrorMock.message, null)
+        val message = oneginiAuthenticatorRegistrationErrorMock.message
+        verify(resultSpy).error(eq(oneginiAuthenticatorRegistrationErrorMock.errorType.toString()), eq(message), any())
     }
 }

--- a/android/src/test/java/com/onegini/mobile/sdk/RegistrationUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/RegistrationUseCaseTests.kt
@@ -17,7 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mock
-import org.mockito.Mockito.verify
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.*
@@ -91,7 +90,7 @@ class RegistrationUseCaseTests {
 
         RegistrationUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(eq(IDENTITY_PROVIDER_NOT_FOUND.code.toString()), eq(IDENTITY_PROVIDER_NOT_FOUND.message), isNull())
+        verify(resultSpy).error(eq(IDENTITY_PROVIDER_NOT_FOUND.code.toString()), eq(IDENTITY_PROVIDER_NOT_FOUND.message), any())
     }
 
     @Test

--- a/android/src/test/java/com/onegini/mobile/sdk/SetPreferredAuthenticatorUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/SetPreferredAuthenticatorUseCaseTests.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -48,7 +49,8 @@ class SetPreferredAuthenticatorUseCaseTests {
 
         SetPreferredAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(USER_PROFILE_DOES_NOT_EXIST.code.toString(), USER_PROFILE_DOES_NOT_EXIST.message, null)
+        val message = USER_PROFILE_DOES_NOT_EXIST.message
+        verify(resultSpy).error(eq(USER_PROFILE_DOES_NOT_EXIST.code.toString()), eq(message), any())
     }
 
     @Test
@@ -59,7 +61,8 @@ class SetPreferredAuthenticatorUseCaseTests {
 
         SetPreferredAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_IS_NULL.code.toString(), AUTHENTICATOR_IS_NULL.message, null)
+        val message = AUTHENTICATOR_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test
@@ -70,7 +73,8 @@ class SetPreferredAuthenticatorUseCaseTests {
 
         SetPreferredAuthenticatorUseCase(clientMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(AUTHENTICATOR_IS_NULL.code.toString(), AUTHENTICATOR_IS_NULL.message, null)
+        val message = AUTHENTICATOR_IS_NULL.message
+        verify(resultSpy).error(eq(AUTHENTICATOR_IS_NULL.code.toString()), eq(message), any())
     }
 
     @Test

--- a/android/src/test/java/com/onegini/mobile/sdk/StartAppUseCaseTests.kt
+++ b/android/src/test/java/com/onegini/mobile/sdk/StartAppUseCaseTests.kt
@@ -71,7 +71,8 @@ class StartAppUseCaseTests {
 
         StartAppUseCase(contextMock, oneginiSDKMock)(callMock, resultSpy)
 
-        verify(resultSpy).error(oneginiInitializationError.errorType.toString(), oneginiInitializationError.message, null)
+        val message = oneginiInitializationError.message
+        verify(resultSpy).error(eq(oneginiInitializationError.errorType.toString()), eq(message), any())
     }
 
     @Test


### PR DESCRIPTION
Due to some earlier changes we had some tests fail, these were not trivially fixable due to some odd behavior with mockito. This commit patches that with a workaround which will have to be fixed later.